### PR TITLE
Add in authentication

### DIFF
--- a/bin/server
+++ b/bin/server
@@ -11,6 +11,7 @@ if (argv.directory) options.directory = argv.directory;
 if (argv.nocolors) options.colors = false;
 if (argv.nologs) options.nologs = true;
 if (argv.help) options.help = true;
+if (argv.auth || argv.a) options.auth = argv.auth || argv.a;
 
 // Run the Server!
 var url = require('../lib/server').run(options);

--- a/lib/login.html
+++ b/lib/login.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>Simple HTTP Server Login</title>
+	<style type="text/css">
+		body {
+			font-family: tahoma; }
+		
+		h1 { text-align: center }
+		fieldset { border: none; }
+		
+		.container { width: 50%; margin: 0 auto; text-align: center; }
+		.container #password { 
+			width: 100%; 
+			height: 30px;
+			font-size: 1.25em;
+			border-radius: 5px;
+			border: 1px solid #CCC; }
+		
+		.container #login { 
+			margin-top: 10px;
+			width: 50px;
+			height: 30px;
+			border-radius: 5px;
+			border: 1px solid #CCC; }
+	</style>
+</head>
+<body>
+	<div class="container">
+		<form method="post" action="auth">
+			<h1>Login</h1>
+			<fieldset>
+				<input type="password" name="password" placeholder="Password" id="password"/>
+				<input type="submit" name="submit" value="Login" id="login" />
+			</fieldset>
+		</form>
+	</div>
+</body>
+</html>

--- a/lib/server.js
+++ b/lib/server.js
@@ -16,7 +16,8 @@
     http: require('http'),
     url: require('url'),
     fs: require('fs'),
-    path: require('path')
+    path: require('path'),
+    qs: require('querystring')
   };
 
   config = exports.config = {
@@ -64,7 +65,7 @@
         };
 
     return mimeTypes[ext.toLowerCase()];
-  }
+  };
 
   BANNER = 'Usage: nserver [options]\n\nIf called without options, `nserver` will listen to the current directory on port ' + config.port + '.';
 
@@ -74,7 +75,8 @@
                 ['', '--launch', 'launch the server in your default browser after starting'],
                 ['', '--nocolors', 'disable colors, default: false'],
                 ['', '--nologs', 'disable request logs, default: false'],
-                ['', '--help', 'show this help screen']
+                ['', '--help', 'show this help screen'],
+                ['-a', '--auth', 'allow a login screen']
               ];
 
   /**
@@ -86,8 +88,8 @@
    *
    * @author Andrew Thorp
    */
+  var isLoggedIn = false;
   exports.run = function(options){
-
     // Options
     if (options !== undefined){
       if (options.help !== undefined) return usage();
@@ -95,6 +97,7 @@
       if (options.directory !== undefined) exports.config.directory = config.directory = options.directory;
       if (options.colors !== undefined) exports.config.colors = config.colors = options.colors;
       if (options.nologs !== undefined) exports.config.nologs = config.nologs = options.nologs;
+      if ( options.auth ) exports.config.auth = config.auth = options.auth;
     }
 
     // Fire off the server!
@@ -109,6 +112,42 @@
       if (path === "/") path += "index.html";
 
       var fullPath = libs.path.join(config.directory, path);
+
+      if ( config.auth && /auth\/?/.test( request.url ) && request.method == 'POST' ) {
+        var body = '';
+        request.on('data', function (data) {
+          body += data;
+        });
+        request.on('end',function(){
+          var POST = libs.qs.parse(body);
+
+          isLoggedIn = options.auth === POST.password;
+
+          response.writeHead(302, {
+            'Location': '/'
+          });
+          response.end();
+        });
+        return;
+      }
+
+      if ( config.auth && !isLoggedIn ) {
+        fullPath = libs.path.join(__dirname, "login.html");
+
+        libs.fs.readFile(fullPath, function(error, data) {
+          console.log( error );
+          if ( !error ){
+            response.writeHead(200, {
+              'content-type': getMimeType( fullPath )
+            });
+            response.write(data);
+            response.end();
+            result += " - 200 AUTHENTICATE".green;
+            logString(result);
+          }
+        });
+        return;
+      }
 
       libs.path.exists(fullPath, function(exists){
 
@@ -214,7 +253,7 @@
       directory: config.directory.green,
       shortDir: "./".green,
       url: "http://localhost:".green + config.port.toString().green + "/".green
-    }
+    };
 
     if (__dirname.indexOf(consoleStrings.directory.stripColors) !== -1){
       currDir = consoleStrings.shortDir;

--- a/lib/server.js
+++ b/lib/server.js
@@ -135,7 +135,6 @@
         fullPath = libs.path.join(__dirname, "login.html");
 
         libs.fs.readFile(fullPath, function(error, data) {
-          console.log( error );
           if ( !error ){
             response.writeHead(200, {
               'content-type': getMimeType( fullPath )


### PR DESCRIPTION
Hey Andrew!
I went ahead and added some auth features.

The basic idea is that you can now do...

``` bash
nserver --auth p@ssw0rd
```

Then when the user hits `localhost:8000`, they'll be directed to a login screen.

The login screen will prompt for a password.

Once the correct password has been entered, the duration of the session will not require any further authentication and will work as normal.

Let me know if you love or hate this, or have any additional questions.

Thanks!
